### PR TITLE
Added pausing for non-Win32 computers

### DIFF
--- a/y-cruncher_mini.cpp
+++ b/y-cruncher_mini.cpp
@@ -1165,4 +1165,5 @@ int main(){
 #else
     cout << "Press Enter to continue . . .";
     std::cin.get();
+#endif 
 }


### PR DESCRIPTION
I fixed the dangling `#ifdef _WIN32` to work with non-Windows machines using standard `std::cin.get()` to enable pausing.
