### PR TITLE
Use threaded fft_inverse()

### DIFF
--- a/mini-pi_optimized_3_OpenMP.cpp
+++ b/mini-pi_optimized_3_OpenMP.cpp
@@ -943,7 +943,7 @@ BigFloat BigFloat::mul(const BigFloat &x,size_t p,int tds) const{
     fft_forward(Ta.get(),k,tds);            //  Transform 1st operand
     fft_forward(Tb.get(),k,tds);            //  Transform 2nd operand
     fft_pointwise(Ta.get(),Tb.get(),k);     //  Pointwise multiply
-    fft_inverse(Ta.get(),k);                //  Perform inverse transform.
+    fft_inverse(Ta.get(),k,tds);            //  Perform inverse transform.
     fft_to_int(Ta.get(),k,z.T.get(),z.L);   //  Convert back to word array.
 
     //  Check top word and correct length.


### PR DESCRIPTION
While playing around with the source, I found that `fft_inverse()` supports threads, but doesn't use them. This is just a quick fix, which seems to increase performance by about 20% (<i>on a Core i5-2540M, on Linux, using Intel C++ Compiler, when doing a 100M digit computation, in the summation stage</i>).

By the way: I'm currently trying to learn about bignum arithmetic. If you got time, maybe you can answer [my question about out-of-core computation on StackOverflow](http://stackoverflow.com/q/28799174/773690). It would be totally great! :)

