### PR TITLE
Fix sign comparison

### DIFF
--- a/decomposed/src/BigFloat.cpp
+++ b/decomposed/src/BigFloat.cpp
@@ -484,7 +484,7 @@ BigFloat BigFloat::mul(const BigFloat &x, size_t p) const{
 
     //  Compute basic fields.
     BigFloat z;
-    z.sign = sign == z.sign;    //  Sign is positive if signs are equal.
+    z.sign = sign == x.sign;    //  Sign is positive if signs are equal.
     z.exp  = Aexp + Bexp;       //  Add the exponents.
     z.L    = AL + BL;           //  Add the lenghts for now. May need to correct later.
 

--- a/mini-pi.cpp
+++ b/mini-pi.cpp
@@ -812,7 +812,7 @@ BigFloat BigFloat::mul(const BigFloat &x, size_t p) const{
 
     //  Compute basic fields.
     BigFloat z;
-    z.sign = sign == z.sign;    //  Sign is positive if signs are equal.
+    z.sign = sign == x.sign;    //  Sign is positive if signs are equal.
     z.exp  = Aexp + Bexp;       //  Add the exponents.
     z.L    = AL + BL;           //  Add the lenghts for now. May need to correct later.
 

--- a/mini-pi_optimized_1_cached_twiddles.cpp
+++ b/mini-pi_optimized_1_cached_twiddles.cpp
@@ -859,7 +859,7 @@ BigFloat BigFloat::mul(const BigFloat &x, size_t p) const{
 
     //  Compute basic fields.
     BigFloat z;
-    z.sign = sign == z.sign;    //  Sign is positive if signs are equal.
+    z.sign = sign == x.sign;    //  Sign is positive if signs are equal.
     z.exp  = Aexp + Bexp;       //  Add the exponents.
     z.L    = AL + BL;           //  Add the lenghts for now. May need to correct later.
 

--- a/mini-pi_optimized_2_SSE3.cpp
+++ b/mini-pi_optimized_2_SSE3.cpp
@@ -863,7 +863,7 @@ BigFloat BigFloat::mul(const BigFloat &x, size_t p) const{
 
     //  Compute basic fields.
     BigFloat z;
-    z.sign = sign == z.sign;    //  Sign is positive if signs are equal.
+    z.sign = sign == x.sign;    //  Sign is positive if signs are equal.
     z.exp  = Aexp + Bexp;       //  Add the exponents.
     z.L    = AL + BL;           //  Add the lenghts for now. May need to correct later.
 

--- a/mini-pi_optimized_3_OpenMP.cpp
+++ b/mini-pi_optimized_3_OpenMP.cpp
@@ -905,7 +905,7 @@ BigFloat BigFloat::mul(const BigFloat &x, size_t p, int tds) const{
 
     //  Compute basic fields.
     BigFloat z;
-    z.sign = sign == z.sign;    //  Sign is positive if signs are equal.
+    z.sign = sign == x.sign;    //  Sign is positive if signs are equal.
     z.exp  = Aexp + Bexp;       //  Add the exponents.
     z.L    = AL + BL;           //  Add the lenghts for now. May need to correct later.
 


### PR DESCRIPTION
It's lucky that x is positive throughout the computation of pi and z's default is positive too.