### PR TITLE
Added Makefile. Allow to specify the number of digits on command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+CXX=g++
+RM=rm -f
+CPPFLAGS=-Wall -Wextra -O3 -g -fopenmp -march=native -std=c++17
+LDFLAGS=-g $(shell root-config --ldflags)
+LDLIBS=$(shell root-config --libs)
+
+SRCS=mini-pi.cpp mini-pi_optimized_1_cached_twiddles.cpp mini-pi_optimized_2_SSE3.cpp mini-pi_optimized_3_OpenMP.cpp
+BINS=$(subst .cpp,,$(SRCS))
+
+all: $(BINS)
+
+%: %.cpp
+		$(CXX) $(CPPFLAGS) -o $@ $<
+
+clean:
+		$(RM) $(BINS)

--- a/mini-pi.cpp
+++ b/mini-pi.cpp
@@ -38,6 +38,7 @@
 #include <memory>
 #include <iostream>
 using std::cout;
+using std::cerr;
 using std::endl;
 using std::complex;
 
@@ -1159,9 +1160,37 @@ void Pi(size_t digits){
 }   //  Namespace: Mini_Pi
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-int main(){
+
+int string_to_double(const char *a, double *r, const double min, const double max) {
+  char *p;
+  double d = strtod(a, &p);
+  if ((p == a) || (*p != 0) || errno == ERANGE || (d < min ) || (d > max ) ) {
+    cerr << "ERROR when parsing \"" << a << "\" as double value. Expecting number in range " << min << " - " << max << " in double notation, see \"man strtod\" for details." << endl;
+    return 1;
+  }
+  *r = d;
+  return 0;
+}
+
+int main(int argc, char** argv){
 
     size_t digits = 1000000;
+    bool parsing_passed = false;
+
+    if ( argc == 2 ) {
+      double x;
+      if ( string_to_double(argv[1], &x, 1000, 800e6) == 0 ) {
+        parsing_passed = true;
+        digits = x;
+      }
+    }
+
+    if (argc >2 || ! parsing_passed) {
+      cerr << "Unsupported number of arguments" << endl;
+      cerr << "Usage: " << argv[0] << " [digits] (max 800 millions). Input in double notation (800e6)" << endl;
+      cerr << "Default value: " << digits << " digits." << endl;
+      return EXIT_FAILURE;
+    }
 
     Mini_Pi::e (digits);
     Mini_Pi::Pi(digits);

--- a/mini-pi_optimized_1_cached_twiddles.cpp
+++ b/mini-pi_optimized_1_cached_twiddles.cpp
@@ -43,6 +43,7 @@
 #include <memory>
 #include <iostream>
 using std::cout;
+using std::cerr;
 using std::endl;
 using std::complex;
 
@@ -1209,9 +1210,37 @@ void Pi(size_t digits){
 }   //  Namespace: Mini_Pi
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-int main(){
+
+int string_to_double(const char *a, double *r, const double min, const double max) {
+  char *p;
+  double d = strtod(a, &p);
+  if ((p == a) || (*p != 0) || errno == ERANGE || (d < min ) || (d > max ) ) {
+    cerr << "ERROR when parsing \"" << a << "\" as double value. Expecting number in range " << min << " - " << max << " in double notation, see \"man strtod\" for details." << endl;
+    return 1;
+  }
+  *r = d;
+  return 0;
+}
+
+int main(int argc, char** argv){
 
     size_t digits = 1000000;
+    bool parsing_passed = false;
+
+    if ( argc == 2 ) {
+      double x;
+      if ( string_to_double(argv[1], &x, 1000, 800e6) == 0 ) {
+        parsing_passed = true;
+        digits = x;
+      }
+    }
+
+    if (argc >2 || ! parsing_passed) {
+      cerr << "Unsupported number of arguments" << endl;
+      cerr << "Usage: " << argv[0] << " [digits] (max 800 millions). Input in double notation (800e6)" << endl;
+      cerr << "Default value: " << digits << " digits." << endl;
+      return EXIT_FAILURE;
+    }
 
     Mini_Pi::e (digits);
     Mini_Pi::Pi(digits);

--- a/mini-pi_optimized_2_SSE3.cpp
+++ b/mini-pi_optimized_2_SSE3.cpp
@@ -43,6 +43,7 @@
 #include <memory>
 #include <iostream>
 using std::cout;
+using std::cerr;
 using std::endl;
 
 //  SIMD
@@ -1214,9 +1215,37 @@ void Pi(size_t digits){
 }   //  Namespace: Mini_Pi
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-int main(){
+
+int string_to_double(const char *a, double *r, const double min, const double max) {
+  char *p;
+  double d = strtod(a, &p);
+  if ((p == a) || (*p != 0) || errno == ERANGE || (d < min ) || (d > max ) ) {
+    cerr << "ERROR when parsing \"" << a << "\" as double value. Expecting number in range " << min << " - " << max << " in double notation, see \"man strtod\" for details." << endl;
+    return 1;
+  }
+  *r = d;
+  return 0;
+}
+
+int main(int argc, char** argv){
 
     size_t digits = 1000000;
+    bool parsing_passed = false;
+
+    if ( argc == 2 ) {
+      double x;
+      if ( string_to_double(argv[1], &x, 1000, 800e6) == 0 ) {
+        parsing_passed = true;
+        digits = x;
+      }
+    }
+
+    if (argc >2 || ! parsing_passed) {
+      cerr << "Unsupported number of arguments" << endl;
+      cerr << "Usage: " << argv[0] << " [digits] (max 800 millions). Input in double notation (800e6)" << endl;
+      cerr << "Default value: " << digits << " digits." << endl;
+      return EXIT_FAILURE;
+    }
 
     Mini_Pi::e (digits);
     Mini_Pi::Pi(digits);


### PR DESCRIPTION
Hi,

I have added the Makefile and enhanced the programs to allow user to specify the number of digits on command line. Could you please have a look and if you like it, merge it? 

```
make
$./mini-pi_optimized_3_OpenMP --help
ERROR when parsing "--help" as double value. Expecting number in range 1000 - 8e+08 in double notation, see "man strtod" for details.
Unsupported number of arguments
Usage: ./mini-pi_optimized_3_OpenMP [digits] (max 800 millions). Input in double notation (800e6)
Default value: 1000000 digits.
OMP_* env variables can be used to control the program. Example: 
OMP_DISPLAY_ENV=TRUE OMP_NUM_THREADS=4 /usr/bin/time -v ./mini-pi_optimized_3_OpenMP 100e6
./mini-pi_optimized_3_OpenMP 

$./mini-pi_optimized_3_OpenMP 1e6
```

Thanks a lot!
Jirka